### PR TITLE
Add mock FastAPI app with OpenAI integration

### DIFF
--- a/app-api/main.py
+++ b/app-api/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from openai import OpenAI
+import os
+
+app = FastAPI()
+MOCK = os.getenv("MOCK_MODE", "0") == "1"
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
+
+
+class GenIn(BaseModel):
+    prompt: str
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.post("/generate")
+def generate(inp: GenIn):
+    if MOCK:
+        return {"text": f"(mock) you said: {inp.prompt}"}
+    if not client:
+        raise HTTPException(status_code=500, detail="Missing OPENAI_API_KEY")
+    try:
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": inp.prompt}],
+            temperature=0.2,
+        )
+        return {"text": resp.choices[0].message.content}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app-api/requirements.txt
+++ b/app-api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pydantic>=2
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- add a FastAPI application with health and text generation endpoints
- support mock responses via the MOCK_MODE environment flag
- provide minimal requirements file for the API service

## Testing
- uvicorn app-api.main:app --host 0.0.0.0 --port 8000 --reload

------
https://chatgpt.com/codex/tasks/task_e_68d5756c4cc88330957ac1a6081dad65