### PR TITLE
Load OpenAI client lazily in generate endpoint

### DIFF
--- a/app-api/main.py
+++ b/app-api/main.py
@@ -1,33 +1,30 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from openai import OpenAI
 import os
 
 app = FastAPI()
 MOCK = os.getenv("MOCK_MODE", "0") == "1"
-api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=api_key) if api_key else None
-
 
 class GenIn(BaseModel):
     prompt: str
-
 
 @app.get("/health")
 def health():
     return {"ok": True}
 
-
 @app.post("/generate")
 def generate(inp: GenIn):
     if MOCK:
         return {"text": f"(mock) you said: {inp.prompt}"}
-    if not client:
-        raise HTTPException(status_code=500, detail="Missing OPENAI_API_KEY")
+
     try:
+        from openai import OpenAI
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        if not client.api_key:
+            raise HTTPException(status_code=500, detail="Missing OPENAI_API_KEY")
         resp = client.chat.completions.create(
             model="gpt-4o-mini",
-            messages=[{"role": "user", "content": inp.prompt}],
+            messages=[{"role":"user","content":inp.prompt}],
             temperature=0.2,
         )
         return {"text": resp.choices[0].message.content}


### PR DESCRIPTION
## Summary
- delay importing OpenAI until the /generate handler runs and mock mode is disabled
- create the OpenAI client inside the handler and validate the API key before use
- keep mock responses unchanged while returning HTTP 500 errors for missing configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d57ad593dc8330a3ab4509bc5cfd95