### PR TITLE
Add static UI for FastAPI generate endpoint

### DIFF
--- a/app-api/main.py
+++ b/app-api/main.py
@@ -1,8 +1,12 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from pydantic import BaseModel
 import os
 
 app = FastAPI()
+static_dir = Path(__file__).parent / "static"
+app.mount("/ui", StaticFiles(directory=static_dir, html=True), name="ui")
 MOCK = os.getenv("MOCK_MODE", "0") == "1"
 
 class GenIn(BaseModel):

--- a/app-api/static/index.html
+++ b/app-api/static/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>OpenAI 8-Week Sprint UI</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:40px;max-width:720px}
+    textarea{width:100%;height:120px}
+    button{padding:8px 12px;margin-top:8px}
+    pre{background:#111;color:#eee;padding:12px;overflow:auto}
+  </style>
+</head>
+<body>
+  <h1>Generate</h1>
+  <textarea id="prompt" placeholder="Type a prompt"></textarea>
+  <br/><button id="go">Send</button>
+  <pre id="out"></pre>
+  <script src="./main.js"></script>
+</body>
+</html>

--- a/app-api/static/main.js
+++ b/app-api/static/main.js
@@ -1,0 +1,13 @@
+const go = document.getElementById('go');
+const ta = document.getElementById('prompt');
+const out = document.getElementById('out');
+go.onclick = async () => {
+  out.textContent = '...';
+  const r = await fetch('/generate', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({prompt: ta.value || 'hello'})
+  });
+  const j = await r.json();
+  out.textContent = JSON.stringify(j, null, 2);
+};


### PR DESCRIPTION
## Summary
- add a simple static UI served from /ui to collect prompts
- mount the static directory in the FastAPI app so the UI is accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58484bef0833080935487f08a9bb2