### PR TITLE
Add API pytest suite and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r app-api/requirements.txt pytest
+      - run: pytest -q

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,26 @@
+import os
+import pathlib
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ["MOCK_MODE"] = "1"
+
+# Load app from file so the hyphen in app-api is not a problem
+from importlib.machinery import SourceFileLoader
+
+mod = SourceFileLoader("app_mod", str(pathlib.Path("app-api/main.py").resolve())).load_module()
+
+from fastapi.testclient import TestClient
+
+client = TestClient(mod.app)
+
+
+def test_health_ok():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_generate_mock():
+    response = client.post("/generate", json={"prompt": "hi"})
+    assert response.status_code == 200
+    assert "(mock)" in response.json()["text"]


### PR DESCRIPTION
## Summary
- add FastAPI integration tests covering /health and /generate endpoints using pytest
- configure a GitHub Actions CI workflow to install dependencies and run pytest
- ensure tests provide a dummy OPENAI_API_KEY so the FastAPI app can import in mock mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d587ffe3448330a5a44c60d95a526a