### PR TITLE
Add content endpoints, mock mode coverage, and UI enhancements

### DIFF
--- a/app-api/main.py
+++ b/app-api/main.py
@@ -1,36 +1,151 @@
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from pathlib import Path
-from pydantic import BaseModel
+from __future__ import annotations
+
+import json
 import os
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 app = FastAPI()
-static_dir = Path(__file__).parent / "static"
-app.mount("/ui", StaticFiles(directory=static_dir, html=True), name="ui")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 MOCK = os.getenv("MOCK_MODE", "0") == "1"
+
 
 class GenIn(BaseModel):
     prompt: str
+
+
+class TextIn(BaseModel):
+    text: str
+
+
+class RewriteIn(BaseModel):
+    text: str
+    tone: str = "concise"
+
+
+def _openai():
+    from openai import OpenAI
+
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    if not client.api_key:
+        raise HTTPException(status_code=500, detail="Missing OPENAI_API_KEY")
+    return client
+
 
 @app.get("/health")
 def health():
     return {"ok": True}
 
+
 @app.post("/generate")
 def generate(inp: GenIn):
     if MOCK:
         return {"text": f"(mock) you said: {inp.prompt}"}
-
     try:
-        from openai import OpenAI
-        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        if not client.api_key:
-            raise HTTPException(status_code=500, detail="Missing OPENAI_API_KEY")
+        client = _openai()
         resp = client.chat.completions.create(
             model="gpt-4o-mini",
-            messages=[{"role":"user","content":inp.prompt}],
+            messages=[{"role": "user", "content": inp.prompt}],
             temperature=0.2,
         )
         return {"text": resp.choices[0].message.content}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - network failures
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/title")
+def title(inp: TextIn):
+    text = inp.text.strip()
+    if MOCK:
+        return {"text": text[:60] or "Untitled"}
+    try:
+        client = _openai()
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "Return a short, punchy title under 60 chars."},
+                {"role": "user", "content": inp.text},
+            ],
+            temperature=0.1,
+        )
+        return {"text": resp.choices[0].message.content.strip()[:60]}
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - network failures
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/summarize")
+def summarize(inp: TextIn):
+    text = inp.text.strip()
+    if MOCK:
+        if not text:
+            return {"text": "No content."}
+        snippet = text[:150]
+        if len(text) > 150:
+            snippet += "..."
+        return {"text": snippet}
+    try:
+        client = _openai()
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "Summarize in one clear sentence."},
+                {"role": "user", "content": inp.text},
+            ],
+            temperature=0.2,
+        )
+        return {"text": resp.choices[0].message.content.strip()}
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - network failures
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/keywords")
+def keywords(inp: TextIn):
+    if MOCK:
+        words = [w.strip(".,!?;:").lower() for w in inp.text.split()]
+        uniq = sorted({w for w in words if len(w) > 3})[:8]
+        return {"keywords": uniq}
+    try:
+        client = _openai()
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "Extract 5–10 key terms as a JSON array of strings."},
+                {"role": "user", "content": inp.text},
+            ],
+            temperature=0.2,
+        )
+        content = resp.choices[0].message.content
+        try:
+            data = json.loads(content)
+            if not isinstance(data, list):
+                raise ValueError("Keywords must be a list")
+            keywords_list = [str(item) for item in data]
+        except (json.JSONDecodeError, ValueError):
+            keywords_list = [kw.strip() for kw in content.split(",") if kw.strip()]
+        return {"keywords": keywords_list}
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - network failures
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+static_dir = Path(__file__).parent / "static"
+if static_dir.exists():
+    app.mount("/ui", StaticFiles(directory=static_dir, html=True), name="ui")

--- a/app-api/static/index.html
+++ b/app-api/static/index.html
@@ -13,7 +13,16 @@
 </head>
 <body>
   <h1>Generate</h1>
-  <textarea id="prompt" placeholder="Type a prompt"></textarea>
+  <label>
+    Mode
+    <select id="mode">
+      <option value="generate">/generate</option>
+      <option value="title">/title</option>
+      <option value="summarize">/summarize</option>
+      <option value="keywords">/keywords</option>
+    </select>
+  </label>
+  <textarea id="prompt" placeholder="Type text or prompt"></textarea>
   <br/><button id="go">Send</button>
   <pre id="out"></pre>
   <script src="./main.js"></script>

--- a/app-api/static/main.js
+++ b/app-api/static/main.js
@@ -1,13 +1,20 @@
 const go = document.getElementById('go');
+const mode = document.getElementById('mode');
 const ta = document.getElementById('prompt');
 const out = document.getElementById('out');
+
 go.onclick = async () => {
   out.textContent = '...';
-  const r = await fetch('/generate', {
+  const endpoint = '/' + mode.value;
+  const body =
+    mode.value === 'generate' ? {prompt: ta.value} :
+    {text: ta.value};
+
+  const response = await fetch(endpoint, {
     method: 'POST',
-    headers: {'Content-Type':'application/json'},
-    body: JSON.stringify({prompt: ta.value || 'hello'})
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body),
   });
-  const j = await r.json();
-  out.textContent = JSON.stringify(j, null, 2);
+
+  out.textContent = JSON.stringify(await response.json(), null, 2);
 };

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,13 +4,11 @@ import pathlib
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ["MOCK_MODE"] = "1"
 
-# Load app from file so the hyphen in app-api is not a problem
 from importlib.machinery import SourceFileLoader
-
-mod = SourceFileLoader("app_mod", str(pathlib.Path("app-api/main.py").resolve())).load_module()
 
 from fastapi.testclient import TestClient
 
+mod = SourceFileLoader("app_mod", str(pathlib.Path("app-api/main.py").resolve())).load_module()
 client = TestClient(mod.app)
 
 
@@ -24,3 +22,45 @@ def test_generate_mock():
     response = client.post("/generate", json={"prompt": "hi"})
     assert response.status_code == 200
     assert "(mock)" in response.json()["text"]
+
+
+def test_title_mock():
+    response = client.post("/title", json={"text": "hello world"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["text"].startswith("hello")
+
+
+def test_title_blank_defaults():
+    response = client.post("/title", json={"text": "   "})
+    assert response.status_code == 200
+    assert response.json()["text"] == "Untitled"
+
+
+def test_summarize_mock_truncates():
+    text = "lorem " * 100
+    response = client.post("/summarize", json={"text": text})
+    assert response.status_code == 200
+    summary = response.json()["text"]
+    assert summary.endswith("...")
+    assert len(summary) <= 153
+
+
+def test_summarize_blank():
+    response = client.post("/summarize", json={"text": ""})
+    assert response.status_code == 200
+    assert response.json()["text"] == "No content."
+
+
+def test_keywords_mock():
+    response = client.post("/keywords", json={"text": "alpha beta gamma delta alpha"})
+    assert response.status_code == 200
+    keywords = response.json()["keywords"]
+    assert sorted(keywords) == keywords  # alphabetical order in mock mode
+    assert "alpha" in keywords and len(keywords) == len(set(keywords))
+
+
+def test_static_ui_served():
+    response = client.get("/ui")
+    assert response.status_code == 200
+    assert "<select" in response.text


### PR DESCRIPTION
## Summary
- add title, summarize, and keywords FastAPI endpoints with CORS and mock fallbacks
- expose static UI mode switch for new endpoints and retain /generate option
- expand pytest coverage for new API routes and static UI delivery

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d592fe487c833088e8e19a0dd8c3ec