### PR TITLE
Add Render static site for app-web

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,3 +8,11 @@ services:
   envVars:
   - key: MOCK_MODE
     value: "1"
+- type: static
+  name: openai-8wk-sprint-web
+  env: static
+  buildCommand: cd app-web && npm ci && npm run build
+  staticPublishPath: app-web/dist
+  envVars:
+  - key: VITE_API_BASE
+    value: https://openai-8wk-sprint-api.onrender.com


### PR DESCRIPTION
## Summary
- add a Render static site configuration for the app-web frontend
- configure build command, publish path, and API base environment variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b34055f88330aeb06eddd3117bab