### PR TITLE
render: valid blueprint with api+web services

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,10 +4,11 @@ services:
   env: python
   plan: free
   buildCommand: pip install -r requirements.txt
-  startCommand: uvicorn app-api.main:app --host 0.0.0.0 --port $PORT
+  startCommand: uvicorn main:app --app-dir app-api --host 0.0.0.0 --port $PORT
   envVars:
   - key: MOCK_MODE
     value: "1"
+
 - type: static
   name: openai-8wk-sprint-web
   env: static


### PR DESCRIPTION
## Summary
- update Render blueprint to point uvicorn at main:app within app-api via --app-dir
- ensure static site references existing API deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b89af038833094a51fc9ffe4c5b4