### PR TITLE
render: fix static site publish path

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,11 +9,10 @@ services:
   - key: MOCK_MODE
     value: "1"
 
-- type: static
-  name: openai-8wk-sprint-web
-  env: static
+staticSites:
+- name: openai-8wk-sprint-web
   buildCommand: cd app-web && npm ci && npm run build
-  staticPublishPath: app-web/dist
+  publishPath: app-web/dist
   envVars:
   - key: VITE_API_BASE
     value: https://openai-8wk-sprint-api.onrender.com


### PR DESCRIPTION
## Summary
- replace `render.yaml` with a corrected static site configuration using the `publishPath` key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5bb8c373c8330b3c0258010f9c80b