### PR TITLE
render: define static site service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,11 +9,10 @@ services:
   - key: MOCK_MODE
     value: "1"
 
-- type: static
+- type: static_site
   name: openai-8wk-sprint-web
-  env: static
   buildCommand: cd app-web && npm ci && npm run build
-  staticPublishPath: app-web/dist
+  publishPath: app-web/dist
   envVars:
   - key: VITE_API_BASE
     value: https://openai-8wk-sprint-api.onrender.com


### PR DESCRIPTION
## Summary
- configure the frontend deployment as a `static_site` service instead of using the `staticSites` section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5bb8c373c8330b3c0258010f9c80b