### PR TITLE
render: restore staticSites entry for web

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,19 +1,18 @@
 services:
-- type: web
-  name: openai-8wk-sprint-api
-  env: python
-  plan: free
-  buildCommand: pip install -r requirements.txt
-  startCommand: uvicorn main:app --app-dir app-api --host 0.0.0.0 --port $PORT
-  envVars:
-  - key: MOCK_MODE
-    value: "1"
+  - type: web
+    name: openai-8wk-sprint-api
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn main:app --app-dir app-api --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: MOCK_MODE
+        value: "1"
 
-- type: static
-  name: openai-8wk-sprint-web
-  env: static
-  buildCommand: cd app-web && npm ci && npm run build
-  staticPublishPath: app-web/dist
-  envVars:
-  - key: VITE_API_BASE
-    value: https://openai-8wk-sprint-api.onrender.com
+staticSites:
+  - name: openai-8wk-sprint-web
+    buildCommand: cd app-web && npm ci && npm run build
+    publishPath: app-web/dist
+    envVars:
+      - key: VITE_API_BASE
+        value: https://openai-8wk-sprint-api.onrender.com


### PR DESCRIPTION
## Summary
- configure the frontend deployment via the `staticSites` section that Render expects for static site definitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5bb8c373c8330b3c0258010f9c80b